### PR TITLE
Restrict piece movement based on collisions, and add available movements based on attacks

### DIFF
--- a/lib/chess/board.rb
+++ b/lib/chess/board.rb
@@ -27,7 +27,7 @@ module Chess
 
       @board_matrix.each_with_index do |row, y|
         row.each_with_index do |square, x|
-          file, rank = matrix_translation(x, y)
+          file, rank = coordinates_to_rank_and_file(x, y)
           case rank
           when 1
             @board_matrix[y][x] = Chess::Piece.new(
@@ -62,6 +62,11 @@ module Chess
       end
     end
 
+    def piece_at_square(file:, rank:)
+      x, y = rank_and_file_to_coordinates(:file => file, :rank => rank)
+      @board_matrix[y][x]
+    end
+
     def score
       score = 0
       @board_matrix.each do |row|
@@ -77,11 +82,18 @@ module Chess
 
     private
 
-    def matrix_translation(x, y)
+    def coordinates_to_rank_and_file(x, y)
       rank = y + 1
       file = (x + FILE_ASCII_CHAR_OFFSET).chr
 
       [file, rank]
+    end
+
+    def rank_and_file_to_coordinates(file:, rank:)
+      y = rank - 1
+      x = file.ord - FILE_ASCII_CHAR_OFFSET
+
+      [x, y]
     end
   end
 end

--- a/lib/chess/knight.rb
+++ b/lib/chess/knight.rb
@@ -1,46 +1,63 @@
 module Chess
   class Knight < Piece
-    def available_moves
-      ascii_file_number = file.ord
+    def available_moves(board)
+      moves = []
 
-      moves = [
+      l_movements = [
         {
-          :file => (ascii_file_number + 1).chr,
-          :rank => @rank + 2
+          :file_shift => 1,
+          :rank_shift => 2
         },
         {
-          :file => (ascii_file_number - 1).chr,
-          :rank => @rank + 2
+          :file_shift => -1,
+          :rank_shift => 2
         },
         {
-          :file => (ascii_file_number + 1).chr,
-          :rank => @rank - 2
+          :file_shift => 1,
+          :rank_shift => -2
         },
         {
-          :file => (ascii_file_number - 1).chr,
-          :rank => @rank - 2
+          :file_shift => -1,
+          :rank_shift => -2
         },
         {
-          :file => (ascii_file_number + 2).chr,
-          :rank => @rank + 1
+          :file_shift => 2,
+          :rank_shift => 1
         },
         {
-          :file => (ascii_file_number - 2).chr,
-          :rank => @rank + 1
+          :file_shift => -2,
+          :rank_shift => 1
         },
         {
-          :file => (ascii_file_number + 2).chr,
-          :rank => @rank - 1
+          :file_shift => 2,
+          :rank_shift => -1
         },
         {
-          :file => (ascii_file_number - 2).chr,
-          :rank => @rank - 1
+          :file_shift => -2,
+          :rank_shift => -1
         }
       ]
 
-      moves.select do |move|
-        Chess::Board.on_board?(move[:file], move[:rank])
+      l_movements.each do |move|
+        next if !Chess::Board.on_board?(
+          file_shift(move[:file_shift]),
+          @rank + move[:rank_shift]
+        )
+
+        piece_at_location = board.piece_at_square(
+          :file => file_shift(move[:file_shift]),
+          :rank => @rank + move[:rank_shift]
+        )
+
+        moves.append(
+          {
+            :file => file_shift(move[:file_shift]),
+            :rank => @rank + move[:rank_shift]
+          }
+        ) unless piece_at_location && piece_at_location.team == @team
       end
+
+      moves
     end
   end
 end

--- a/lib/chess/pawn.rb
+++ b/lib/chess/pawn.rb
@@ -1,7 +1,17 @@
 module Chess
   class Pawn < Piece
-    def available_moves
-      return [
+    def available_moves(board)
+      if board.piece_at_square(:file => @file, :rank => @rank + 1)
+        return []
+      elsif board.piece_at_square(:file => @file, :rank => @rank + 2)
+        return [
+          {
+            :file => @file,
+            :rank => @rank + 1
+          }
+        ]
+      elsif !@moved
+        return [
           {
             :file => @file,
             :rank => @rank + 2
@@ -10,13 +20,19 @@ module Chess
             :file => @file,
             :rank => @rank + 1
           }
-        ] unless @moved
-      [
-        {
-          :file => @file,
-          :rank => @rank + 1
-        }
-    ]
+        ]
+      else
+        [
+          {
+            :file => @file,
+            :rank => @rank + 1
+          }
+        ]
+      end
     end
   end
 end
+
+
+# check for a piece in @rank + 1, or @rank + 2 if unmoved (current file)
+# check for rank + 1 and file + 1 (or -1) and opposite color

--- a/lib/chess/pawn.rb
+++ b/lib/chess/pawn.rb
@@ -1,38 +1,36 @@
 module Chess
   class Pawn < Piece
     def available_moves(board)
-      if board.piece_at_square(:file => @file, :rank => @rank + 1)
+      direction = @team == Chess::Piece::Team::WHITE ? 1 : -1
+
+      if board.piece_at_square(:file => @file, :rank => @rank + direction)
         return []
-      elsif board.piece_at_square(:file => @file, :rank => @rank + 2)
+      elsif board.piece_at_square(:file => @file, :rank => @rank + 2 * direction)
         return [
           {
             :file => @file,
-            :rank => @rank + 1
+            :rank => @rank + direction
           }
         ]
       elsif !@moved
         return [
           {
             :file => @file,
-            :rank => @rank + 2
+            :rank => @rank + 2 * direction
           },
           {
             :file => @file,
-            :rank => @rank + 1
+            :rank => @rank + direction
           }
         ]
       else
         [
           {
             :file => @file,
-            :rank => @rank + 1
+            :rank => @rank + direction
           }
         ]
       end
     end
   end
 end
-
-
-# check for a piece in @rank + 1, or @rank + 2 if unmoved (current file)
-# check for rank + 1 and file + 1 (or -1) and opposite color

--- a/lib/chess/pawn.rb
+++ b/lib/chess/pawn.rb
@@ -3,33 +3,53 @@ module Chess
     def available_moves(board)
       direction = @team == Chess::Piece::Team::WHITE ? 1 : -1
 
+      moves = []
+      if Chess::Board.on_board?(file_shift(1), @rank + direction) && board.piece_at_square(:file => file_shift(1), :rank => @rank + direction)
+        moves.append(
+          {
+            :file => file_shift(1),
+            :rank => @rank + direction
+          }
+        )
+      end
+      if Chess::Board.on_board?(file_shift(-1), @rank + direction) && board.piece_at_square(:file => file_shift(-1), :rank => @rank + direction)
+        moves.append(
+          {
+            :file => file_shift(-1),
+            :rank => @rank + direction
+          }
+        )
+      end
+
       if board.piece_at_square(:file => @file, :rank => @rank + direction)
-        return []
+        moves
       elsif board.piece_at_square(:file => @file, :rank => @rank + 2 * direction)
-        return [
+        return moves.append(
           {
             :file => @file,
             :rank => @rank + direction
           }
-        ]
+        )
       elsif !@moved
-        return [
+        moves.append(
           {
             :file => @file,
             :rank => @rank + 2 * direction
-          },
+          }
+        )
+        moves.append(
           {
             :file => @file,
             :rank => @rank + direction
           }
-        ]
+        )
       else
-        [
+        moves.append(
           {
             :file => @file,
             :rank => @rank + direction
           }
-        ]
+        )
       end
     end
   end

--- a/lib/chess/piece.rb
+++ b/lib/chess/piece.rb
@@ -54,9 +54,7 @@ module Chess
     end
 
     def file_shift(shift_value)
-      return (@file.ord + shift_value).chr if Chess::Board.on_board?((@file.ord + shift_value).chr, @rank)
-
-      raise
+      (@file.ord + shift_value).chr
     end
   end
 end

--- a/lib/chess/piece.rb
+++ b/lib/chess/piece.rb
@@ -52,5 +52,11 @@ module Chess
       raise unless Value::VALUES.key?(@type)
       @team == Team::WHITE ? Value::VALUES[@type] : -Value::VALUES[@type]
     end
+
+    def file_shift(shift_value)
+      return (@file.ord + shift_value).chr if Chess::Board.on_board?((@file.ord + shift_value).chr, @rank)
+
+      raise
+    end
   end
 end

--- a/spec/chess/board_spec.rb
+++ b/spec/chess/board_spec.rb
@@ -209,4 +209,23 @@ RSpec.describe Chess::Board do
       end
     end
   end
+
+  describe "#piece_at_square" do
+    subject { described_class.new }
+
+    context "when asking for a piece at a location on a board" do
+      let(:king) do
+        Chess::Piece.new(:team => Chess::Piece::Team::WHITE,
+          :type => Chess::Piece::Type::KING,
+          :file => "e",
+          :rank => 1
+        )
+      end
+
+      it "returns that piece object" do
+        expect(subject.piece_at_square(:file => "e", :rank => 1)).to eq(king)
+      end
+    end
+
+  end
 end

--- a/spec/chess/knight_spec.rb
+++ b/spec/chess/knight_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe Chess::Knight do
         )
       end
 
+      let(:board_matrix) do
+        [
+          Array.new(8),
+          Array.new(8),
+          Array.new(8),
+          [nil, nil, nil, subject, nil, nil, nil, nil],
+          Array.new(8),
+          Array.new(8),
+          Array.new(8),
+          Array.new(8)
+        ]
+      end
+      let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
+
       let(:available_moves) do
         [
           {
@@ -50,7 +64,7 @@ RSpec.describe Chess::Knight do
       end
 
       it "returns 8 moves" do
-        expect(subject.available_moves).to match_array(available_moves)
+        expect(subject.available_moves(board)).to match_array(available_moves)
       end
     end
 
@@ -65,6 +79,21 @@ RSpec.describe Chess::Knight do
           )
         end
 
+        let(:board_matrix) do
+          [
+            Array.new(8),
+            Array.new(8),
+            [subject, nil, nil, nil, nil, nil, nil, nil],
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8)
+          ]
+        end
+
+        let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
+
         let(:available_moves) do
           [
             {
@@ -87,7 +116,7 @@ RSpec.describe Chess::Knight do
         end
 
         it "does not return moves below file a" do
-          expect(subject.available_moves).to match_array(available_moves)
+          expect(subject.available_moves(board)).to match_array(available_moves)
         end
       end
 
@@ -101,6 +130,21 @@ RSpec.describe Chess::Knight do
           )
         end
 
+        let(:board_matrix) do
+          [
+            Array.new(8),
+            Array.new(8),
+            [nil, subject, nil, nil, nil, nil, nil, nil],
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8)
+          ]
+        end
+
+        let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
+
         let(:available_moves) do
           [
             {
@@ -131,7 +175,7 @@ RSpec.describe Chess::Knight do
         end
 
         it "does not return moves below file a" do
-          expect(subject.available_moves).to match_array(available_moves)
+          expect(subject.available_moves(board)).to match_array(available_moves)
         end
       end
 
@@ -145,6 +189,21 @@ RSpec.describe Chess::Knight do
           )
         end
 
+        let(:board_matrix) do
+          [
+            Array.new(8),
+            Array.new(8),
+            [nil, nil, nil, nil, nil, nil, subject, nil],
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8)
+          ]
+        end
+
+        let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
+
         let(:available_moves) do
           [
             {
@@ -175,7 +234,7 @@ RSpec.describe Chess::Knight do
         end
 
         it "does not return moves above file h" do
-          expect(subject.available_moves).to match_array(available_moves)
+          expect(subject.available_moves(board)).to match_array(available_moves)
         end
       end
 
@@ -189,6 +248,21 @@ RSpec.describe Chess::Knight do
           )
         end
 
+        let(:board_matrix) do
+          [
+            Array.new(8),
+            Array.new(8),
+            [nil, nil, nil, nil, nil, nil, nil, subject],
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8)
+          ]
+        end
+
+        let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
+
         let(:available_moves) do
           [
             {
@@ -211,7 +285,7 @@ RSpec.describe Chess::Knight do
         end
 
         it "does not return moves above file h" do
-          expect(subject.available_moves).to match_array(available_moves)
+          expect(subject.available_moves(board)).to match_array(available_moves)
         end
       end
 
@@ -224,6 +298,21 @@ RSpec.describe Chess::Knight do
             :rank => 1
           )
         end
+
+        let(:board_matrix) do
+          [
+            [nil, nil, nil, nil, nil, nil, nil, subject],
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8)
+          ]
+        end
+
+        let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
 
         let(:available_moves) do
           [
@@ -239,7 +328,7 @@ RSpec.describe Chess::Knight do
         end
 
         it "does not return moves below rank 1" do
-          expect(subject.available_moves).to match_array(available_moves)
+          expect(subject.available_moves(board)).to match_array(available_moves)
         end
       end
 
@@ -252,6 +341,21 @@ RSpec.describe Chess::Knight do
             :rank => 3
           )
         end
+
+        let(:board_matrix) do
+          [
+            Array.new(8),
+            Array.new(8),
+            [nil, nil, nil, nil, nil, nil, subject, nil],
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8)
+          ]
+        end
+
+        let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
 
         let(:available_moves) do
           [
@@ -283,7 +387,7 @@ RSpec.describe Chess::Knight do
         end
 
         it "does not return moves below rank 1" do
-          expect(subject.available_moves).to match_array(available_moves)
+          expect(subject.available_moves(board)).to match_array(available_moves)
         end
       end
 
@@ -296,6 +400,21 @@ RSpec.describe Chess::Knight do
             :rank => 7
           )
         end
+
+        let(:board_matrix) do
+          [
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            [nil, nil, nil, nil, nil, nil, nil, subject],
+            Array.new(8)
+          ]
+        end
+
+        let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
 
         let(:available_moves) do
           [
@@ -315,7 +434,7 @@ RSpec.describe Chess::Knight do
         end
 
         it "does not return moves above rank 8" do
-          expect(subject.available_moves).to match_array(available_moves)
+          expect(subject.available_moves(board)).to match_array(available_moves)
         end
       end
 
@@ -328,6 +447,21 @@ RSpec.describe Chess::Knight do
             :rank => 8
           )
         end
+
+        let(:board_matrix) do
+          [
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            Array.new(8),
+            [nil, nil, nil, nil, nil, nil, nil, subject]
+          ]
+        end
+
+        let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
 
         let(:available_moves) do
           [
@@ -343,8 +477,138 @@ RSpec.describe Chess::Knight do
         end
 
         it "does not return moves above rank 8" do
-          expect(subject.available_moves).to match_array(available_moves)
+          expect(subject.available_moves(board)).to match_array(available_moves)
         end
+      end
+    end
+
+    context "when same team pieces restrict movement" do
+      subject do
+        described_class.new(
+          :team => described_class::Team::WHITE,
+          :type => described_class::Type::KNIGHT,
+          :file => "d",
+          :rank => 4
+        )
+      end
+
+      let(:board_matrix) do
+        [
+          Array.new(8),
+          [nil, nil, Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::KING, :file => "c", :rank => 2), nil, nil, nil, nil, nil],
+          Array.new(8),
+          [nil, nil, nil, subject, nil, nil, nil, nil],
+          Array.new(8),
+          Array.new(8),
+          Array.new(8),
+          Array.new(8)
+        ]
+      end
+
+      let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
+
+      let(:available_moves) do
+        [
+          {
+            :file => "b",
+            :rank => 3
+          },
+          {
+            :file => "b",
+            :rank => 5
+          },
+          {
+            :file => "c",
+            :rank => 6
+          },
+          {
+            :file => "e",
+            :rank => 6
+          },
+          {
+            :file => "f",
+            :rank => 5
+          },
+          {
+            :file => "f",
+            :rank => 3
+          },
+          {
+            :file => "e",
+            :rank => 2
+          }
+        ]
+      end
+
+      it "returns 7 moves" do
+        expect(subject.available_moves(board)).to match_array(available_moves)
+      end
+    end
+
+    context "when enemy team pieces occupy an available movement square" do
+      subject do
+        described_class.new(
+          :team => described_class::Team::WHITE,
+          :type => described_class::Type::KNIGHT,
+          :file => "d",
+          :rank => 4
+        )
+      end
+
+      let(:board_matrix) do
+        [
+          Array.new(8),
+          [nil, nil, Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::KNIGHT, :file => "c", :rank => 2), nil, nil, nil, nil, nil],
+          Array.new(8),
+          [nil, nil, nil, subject, nil, nil, nil, nil],
+          Array.new(8),
+          Array.new(8),
+          Array.new(8),
+          Array.new(8)
+        ]
+      end
+
+      let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
+
+      let(:available_moves) do
+        [
+          {
+            :file => "c",
+            :rank => 2
+          },
+          {
+            :file => "b",
+            :rank => 3
+          },
+          {
+            :file => "b",
+            :rank => 5
+          },
+          {
+            :file => "c",
+            :rank => 6
+          },
+          {
+            :file => "e",
+            :rank => 6
+          },
+          {
+            :file => "f",
+            :rank => 5
+          },
+          {
+            :file => "f",
+            :rank => 3
+          },
+          {
+            :file => "e",
+            :rank => 2
+          }
+        ]
+      end
+
+      it "returns 8 moves" do
+        expect(subject.available_moves(board)).to match_array(available_moves)
       end
     end
   end

--- a/spec/chess/pawn_spec.rb
+++ b/spec/chess/pawn_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Chess::Pawn do
           }
         ]
       end
-
       it "returns two possible moves" do
         expect(subject.available_moves(board)).to match_array(available_moves)
       end
@@ -247,6 +246,88 @@ RSpec.describe Chess::Pawn do
       end
 
       it "has one available move" do
+        expect(subject.available_moves(board)).to match_array(available_moves)
+      end
+    end
+
+    context "when a pawn is threatening a piece" do
+      subject do
+        described_class.new(
+          :team => described_class::Team::WHITE,
+          :type => described_class::Type::PAWN,
+          :file => "e",
+          :rank => 4
+        )
+      end
+
+      let(:board_matrix) do
+        [
+          [
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::ROOK, :file => "a", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::KNIGHT, :file => "b", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::BISHOP, :file => "c", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::QUEEN, :file => "d", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::KING, :file => "e", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::BISHOP, :file => "f", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::KNIGHT, :file => "g", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::ROOK, :file => "h", :rank => 1)
+          ],
+          [
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "a", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "b", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "c", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "d", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "e", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "f", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "g", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "h", :rank => 2)
+          ],
+          Array.new(8),
+          Array.new(8),
+          [nil, nil, nil, Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "d", :rank => 5), nil, nil, nil, nil],
+          Array.new(8),
+          Array.new(8),
+          [
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "a", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "b", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "c", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "d", :rank => 7),
+            nil,
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "f", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "g", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "h", :rank => 7)
+          ],
+          [
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::ROOK, :file => "a", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::KNIGHT, :file => "b", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::BISHOP, :file => "c", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::KING, :file => "d", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::QUEEN, :file => "e", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::BISHOP, :file => "f", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::KNIGHT, :file => "g", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::ROOK, :file => "h", :rank => 8)
+          ],
+        ]
+      end
+
+      let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
+
+      let(:available_moves) do
+        [
+          {
+            :file => "e",
+            :rank => 5
+          },
+          {
+            :file => "d",
+            :rank => 5
+          },
+        ]
+      end
+
+      it "has 2 available moves" do
+        subject.move_to(:file => "e", :rank => 3)
+        subject.move_to(:file => "e", :rank => 4)
         expect(subject.available_moves(board)).to match_array(available_moves)
       end
     end

--- a/spec/chess/pawn_spec.rb
+++ b/spec/chess/pawn_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 RSpec.describe Chess::Pawn do
   describe "#available_moves" do
+    let(:board) { Chess::Board.new }
+
     context "when a pawn has not yet moved" do
       subject do
         described_class.new(
@@ -26,7 +28,7 @@ RSpec.describe Chess::Pawn do
       end
 
       it "returns two possible moves" do
-        expect(subject.available_moves).to match_array(available_moves)
+        expect(subject.available_moves(board)).to match_array(available_moves)
       end
     end
 
@@ -51,7 +53,148 @@ RSpec.describe Chess::Pawn do
 
       it "returns one move" do
         subject.move_to(:file => "a", :rank => 3)
-        expect(subject.available_moves).to match_array(available_moves)
+        expect(subject.available_moves(board)).to match_array(available_moves)
+      end
+    end
+
+    context "when a pawn is blocked by another piece direcly in front of it" do
+      subject do
+        described_class.new(
+          :team => described_class::Team::WHITE,
+          :type => described_class::Type::PAWN,
+          :file => "e",
+          :rank => 4
+        )
+      end
+
+      let(:board_matrix) do
+        [
+          [
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::ROOK, :file => "a", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::KNIGHT, :file => "b", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::BISHOP, :file => "c", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::QUEEN, :file => "d", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::KING, :file => "e", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::BISHOP, :file => "f", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::KNIGHT, :file => "g", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::ROOK, :file => "h", :rank => 1)
+          ],
+          [
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "a", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "b", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "c", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "d", :rank => 2),
+            nil,
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "f", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "g", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "h", :rank => 2)
+          ],
+          Array.new(8),
+          [nil, nil, nil, nil, subject, nil, nil, nil],
+          [nil, nil, nil, nil, Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "e", :rank => 5), nil, nil, nil],
+          Array.new(8),
+          Array.new(8),
+          [
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "a", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "b", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "c", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "d", :rank => 7),
+            nil,
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "f", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "g", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "h", :rank => 7)
+          ],
+          [
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::ROOK, :file => "a", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::KNIGHT, :file => "b", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::BISHOP, :file => "c", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::KING, :file => "d", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::QUEEN, :file => "e", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::BISHOP, :file => "f", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::KNIGHT, :file => "g", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::ROOK, :file => "h", :rank => 8)
+          ],
+        ]
+      end
+      let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
+
+      it "has no available moves" do
+        expect(subject.available_moves(board)).to eq([])
+      end
+    end
+
+    context "when a pawn is blocked by another piece two squares in front of it" do
+      subject do
+        described_class.new(
+          :team => described_class::Team::WHITE,
+          :type => described_class::Type::PAWN,
+          :file => "e",
+          :rank => 4
+        )
+      end
+
+      let(:board_matrix) do
+        [
+          [
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::ROOK, :file => "a", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::KNIGHT, :file => "b", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::BISHOP, :file => "c", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::QUEEN, :file => "d", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::KING, :file => "e", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::BISHOP, :file => "f", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::KNIGHT, :file => "g", :rank => 1),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::ROOK, :file => "h", :rank => 1)
+          ],
+          [
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "a", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "b", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "c", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "d", :rank => 2),
+            nil,
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "f", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "g", :rank => 2),
+            Chess::Piece.new(:team => Chess::Piece::Team::WHITE, :type => Chess::Piece::Type::PAWN, :file => "h", :rank => 2)
+          ],
+          Array.new(8),
+          [nil, nil, nil, nil, subject, nil, nil, nil],
+          Array.new(8),
+          [nil, nil, nil, nil, Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "e", :rank => 6), nil, nil, nil],
+          Array.new(8),
+          [
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "a", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "b", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "c", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "d", :rank => 7),
+            nil,
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "f", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "g", :rank => 7),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::PAWN, :file => "h", :rank => 7)
+          ],
+          [
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::ROOK, :file => "a", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::KNIGHT, :file => "b", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::BISHOP, :file => "c", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::KING, :file => "d", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::QUEEN, :file => "e", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::BISHOP, :file => "f", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::KNIGHT, :file => "g", :rank => 8),
+            Chess::Piece.new(:team => Chess::Piece::Team::BLACK, :type => Chess::Piece::Type::ROOK, :file => "h", :rank => 8)
+          ],
+        ]
+      end
+      let(:board) { Chess::Board.new(:board_matrix => board_matrix) }
+
+      let(:available_moves) do
+        [
+          {
+            :file => "e",
+            :rank => 5
+          }
+        ]
+      end
+
+      it "has one available move" do
+        expect(subject.available_moves(board)).to match_array(available_moves)
       end
     end
   end

--- a/spec/chess/pawn_spec.rb
+++ b/spec/chess/pawn_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Chess::Pawn do
   describe "#available_moves" do
     let(:board) { Chess::Board.new }
 
-    context "when a pawn has not yet moved" do
+    context "when a white pawn has not yet moved" do
       subject do
         described_class.new(
           :team => described_class::Team::WHITE,
@@ -32,7 +32,7 @@ RSpec.describe Chess::Pawn do
       end
     end
 
-    context "when a pawn has moved" do
+    context "when a white pawn has moved" do
       subject do
         described_class.new(
           :team => described_class::Team::WHITE,
@@ -53,6 +53,59 @@ RSpec.describe Chess::Pawn do
 
       it "returns one move" do
         subject.move_to(:file => "a", :rank => 3)
+        expect(subject.available_moves(board)).to match_array(available_moves)
+      end
+    end
+
+    context "when a black pawn has not yet moved" do
+      subject do
+        described_class.new(
+          :team => described_class::Team::BLACK,
+          :type => described_class::Type::PAWN,
+          :file => "a",
+          :rank => 7
+        )
+      end
+
+      let(:available_moves) do
+        [
+          {
+            :file => "a",
+            :rank => 6
+          },
+          {
+            :file => "a",
+            :rank => 5
+          }
+        ]
+      end
+
+      it "returns two possible moves" do
+        expect(subject.available_moves(board)).to match_array(available_moves)
+      end
+    end
+
+    context "when a black pawn has moved" do
+      subject do
+        described_class.new(
+          :team => described_class::Team::BLACK,
+          :type => described_class::Type::PAWN,
+          :file => "a",
+          :rank => 7
+        )
+      end
+
+      let(:available_moves) do
+        [
+          {
+            :file => "a",
+            :rank => 5
+          }
+        ]
+      end
+
+      it "returns one move" do
+        subject.move_to(:file => "a", :rank => 6)
         expect(subject.available_moves(board)).to match_array(available_moves)
       end
     end

--- a/spec/chess/piece_spec.rb
+++ b/spec/chess/piece_spec.rb
@@ -123,4 +123,33 @@ RSpec.describe Chess::Piece do
       expect { subject.move_to(:file => "b", :rank => 3) }.to change { subject.file }.from("a").to("b")
     end
   end
+
+  describe "#file_shift" do
+    subject do
+      described_class.new(
+        :team => described_class::Team::WHITE,
+        :type => described_class::Type::PAWN,
+        :file => "b",
+        :rank => 2
+      )
+    end
+
+    context "when shifting positively" do
+      it "returns the next letter file alphabetically" do
+        expect(subject.file_shift(1)).to eq("c")
+      end
+    end
+
+    context "when shifting negatively" do
+      it "returns the next letter file alphabetically" do
+        expect(subject.file_shift(-1)).to eq("a")
+      end
+    end
+
+    context "when shifting off board" do
+      it "raises an error" do
+        expect { subject.file_shift(-2) }.to raise_error
+      end
+    end
+  end
 end

--- a/spec/chess/piece_spec.rb
+++ b/spec/chess/piece_spec.rb
@@ -147,8 +147,8 @@ RSpec.describe Chess::Piece do
     end
 
     context "when shifting off board" do
-      it "raises an error" do
-        expect { subject.file_shift(-2) }.to raise_error
+      it "returns a square not on the board" do
+        expect(Chess::Board.on_board?(subject.file_shift(-2), subject.rank)).to eq(false)
       end
     end
   end


### PR DESCRIPTION
* prevent pieces from moving _into_ squares occupied by another piece of the same team
* prevent pieces from moving _beyond_ (when applicable) squares where same team pieces occupy the square
* allow pieces to move into squares occupied by a piece of the other team
* allow movements based on position of other teams pieces (pawn movements)